### PR TITLE
fix(command): immediately handle disable state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- ## [vNext](https://github.com/sktch7/ngx.command/compare/2.0.0...3.0.0) (2020-x-x) -->
 
-## [2.0.1](https://github.com/sketch7/ngx.command/compare/2.0.0...2.0.1) (2021-11-11)
+## [2.0.1](https://github.com/sketch7/ngx.command/compare/2.0.0...2.0.1) (2021-11-12)
+
+### Features
+
+- **command:** add input `ssvCommandDisabled`
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 <!-- ## [vNext](https://github.com/sktch7/ngx.command/compare/2.0.0...3.0.0) (2020-x-x) -->
 
+## [2.0.1](https://github.com/sketch7/ngx.command/compare/2.0.0...2.0.1) (2021-11-11)
+
+### Bug Fixes
+
+- **command:** immediately handle disable state to eliminate transition on init
+
 ## [2.0.0](https://github.com/sketch7/ngx.command/compare/1.6.0...2.0.0) (2021-08-25)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssv/ngx.command",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "versionSuffix": "",
   "description": "Command pattern implementation for angular. Command used to encapsulate information which is needed to perform an action.",
   "keywords": [

--- a/src/command.directive.ts
+++ b/src/command.directive.ts
@@ -87,21 +87,20 @@ export class CommandDirective implements OnInit, OnDestroy {
 
 	@Input("disabled")
 	set disabledInput(value: boolean) {
-		this.disabled = value;
+		this.setDisabled(value);
 	}
 
 	@HostBinding("attr.disabled")
-	get disabled(): boolean | undefined { return this._disabled; }
-	set disabled(value: boolean | undefined) {
-		const disabled = value ? value : undefined;
+	get disabled(): "" | undefined { return this._disabled; }
+	set disabled(value: "" | undefined) {
 		if (value === this._disabled) {
 			return;
 		}
-		this._disabled = disabled;
+		this._disabled = value;
 	}
 
 	get command(): ICommand { return this._command; }
-	private _disabled: boolean | undefined;
+	private _disabled: "" | undefined;
 	private _command!: ICommand;
 	private _commandOptions: CommandOptions = this.config;
 	private _destroy$ = new Subject<void>();
@@ -114,7 +113,9 @@ export class CommandDirective implements OnInit, OnDestroy {
 	) { }
 
 	ngOnInit(): void {
-		this.setDisabled(true);
+		if (this.commandOptions.handleDisabled) {
+			this.setDisabled(true);
+		}
 		// console.log("[ssvCommand::init]", this.config);
 		if (!this.commandOrCreator) {
 			throw new Error("ssvCommand: [ssvCommand] should be defined!");
@@ -144,7 +145,7 @@ export class CommandDirective implements OnInit, OnDestroy {
 
 		this._command.subscribe();
 		this._command.canExecute$.pipe(
-			tap(canExecute => this.setDisabled(!canExecute)),
+			tap(canExecute => this.commandOptions.handleDisabled && this.setDisabled(!canExecute)),
 			tap(() => this.cdr.markForCheck()),
 			takeUntil(this._destroy$),
 		).subscribe();
@@ -190,10 +191,7 @@ export class CommandDirective implements OnInit, OnDestroy {
 	}
 
 	private setDisabled(disabled: boolean) {
-		if (this.commandOptions.handleDisabled) {
-			this.disabled = disabled;
-		}
-
+		this.disabled = disabled ? "" : undefined;
 	}
 
 }


### PR DESCRIPTION
wanted to handle the state immediately rather than relying on a delay as it is causing the disable state to change after view init

____

unsure if I broke anything yet, but seems to be working (will run more tests)