### PR TITLE
fix(utils): `canExecuteFromNgForm` add delay to cater for pristine changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 <!-- ## [vNext](https://github.com/sktch7/ngx.command/compare/2.0.0...3.0.0) (2020-x-x) -->
 
+## [2.1.0](https://github.com/sketch7/ngx.command/compare/2.0.0...2.1.0) (2022-07-12)
+
+### Features
+
+- **util:** `canExecuteFromNgForm` now have delay(0) which is fixing issue when observable `form.statusChanges` wasn't triggered after reset or make pristine form from the code.
+
 ## [2.0.0](https://github.com/sketch7/ngx.command/compare/1.6.0...2.0.0) (2021-08-25)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssv/ngx.command",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "versionSuffix": "",
   "description": "Command pattern implementation for angular. Command used to encapsulate information which is needed to perform an action.",
   "keywords": [

--- a/src/command.util.ts
+++ b/src/command.util.ts
@@ -1,6 +1,6 @@
 import { AbstractControl, AbstractControlDirective } from "@angular/forms";
 import { Observable, of } from "rxjs";
-import { map, distinctUntilChanged, startWith } from "rxjs/operators";
+import { map, distinctUntilChanged, startWith, delay } from "rxjs/operators";
 
 import { CommandCreator, ICommand } from "./command.model";
 import { Command } from "./command";
@@ -37,6 +37,7 @@ export function canExecuteFromNgForm(
 
 	return form.statusChanges
 		? form.statusChanges.pipe(
+			delay(0),
 			startWith(form.valid),
 			map(() => !!(!opts.validity || form.valid) && !!(!opts.dirty || form.dirty)),
 			distinctUntilChanged(),


### PR DESCRIPTION
When we try to patch form from the code, canExecuteFromNgForm still returns false after reset or makePristine form from the code and ssv commands inside crud-form-view remain blocked.